### PR TITLE
Fixed Issue #9 for GH Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,5 +19,5 @@ jobs:
         cache: 'pip'
     - run: |
         python -m pip install --upgrade pip
-        python -m pip install -r requirements.txt
+        python -m pip install -e ".[dev]"
         python -m pytest


### PR DESCRIPTION
fix: Install package in development mode with [dev] extra for GH Actions

This commit addresses GitHub issue #9, where the GitHub Actions workflow was loading more dependencies than needed. The solution is to install the package locally in development mode with the [dev] extra, ensuring that only necessary dependencies are installed during CI testing.

Command used:
```bash
python -m pip install -e ".[dev]"

Fixes #9